### PR TITLE
feat: activitylog extension page added

### DIFF
--- a/src/activitylog/activitylog.css
+++ b/src/activitylog/activitylog.css
@@ -1,1 +1,120 @@
-/* activitylog.css */
+*,
+*:before,
+*:after {
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+}
+
+.container {
+  width: 100%;
+}
+
+#showActivityLog,
+#showLoadedLog,
+#saveLogBtn {
+  margin-top: 20px;
+}
+
+.activity-log-wrapper {
+  position: relative;
+}
+
+.show-log-detail-wrapper {
+  position: absolute;
+  top: 0;
+  height: 500px;
+  right: 0;
+  width: 40%;
+  display: none;
+  word-wrap: anywhere;
+  background-color: #ffffff;
+  border: 2px solid #000000;
+}
+
+#showLogDetails {
+  margin: 50px 15px 10px;
+}
+
+.log-table table {
+  width: 100%;
+}
+
+.log-table table tbody tr {
+  text-align: center;
+}
+
+table {
+  width: 100%;
+  border: 1px solid #eeeeee;
+}
+
+th {
+  width: 100%;
+  background: #000;
+  padding: 5px;
+  text-transform: uppercase;
+  color: #ffffff;
+}
+
+tr {
+  display: flex;
+  width: 100%;
+}
+
+tr:nth-of-type(odd) {
+  background: #eeeeee;
+}
+
+td,
+th {
+  flex: 1 1 20%;
+  text-align: center;
+  word-wrap: anywhere;
+  align-self: center;
+}
+
+table td {
+  padding: 3px;
+}
+
+.failure {
+  background-color: #961616;
+  padding: 10px;
+  color: #ffffff;
+}
+
+.log-table {
+  overflow-y: scroll;
+  max-height: 500px;
+  height: auto;
+}
+
+table tr:first-child {
+  position: sticky;
+  top: 0;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+  cursor: pointer;
+}
+
+.width-60 {
+  width: 60%;
+}
+
+.close {
+  background: url(/icons/close.svg) no-repeat center center / cover;
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  top: 5px;
+  right: 5px;
+  cursor: pointer;
+}
+
+.activity-log-container {
+  position: relative;
+}

--- a/src/activitylog/activitylog.css
+++ b/src/activitylog/activitylog.css
@@ -25,7 +25,6 @@
   height: 500px;
   right: 0;
   width: 40%;
-  display: none;
   word-wrap: anywhere;
   background-color: #ffffff;
   border: 2px solid #000000;

--- a/src/activitylog/activitylog.css
+++ b/src/activitylog/activitylog.css
@@ -11,9 +11,8 @@
 }
 
 #showActivityLog,
-#showLoadedLog,
 #saveLogBtn {
-  margin-top: 20px;
+  margin: 20px 0;
 }
 
 .activity-log-wrapper {
@@ -38,10 +37,6 @@
 
 .log-table table {
   width: 100%;
-}
-
-.log-table table tbody tr {
-  text-align: center;
 }
 
 table {
@@ -90,7 +85,7 @@ table td {
   height: auto;
 }
 
-table tr:first-child {
+table thead {
   position: sticky;
   top: 0;
 }

--- a/src/activitylog/activitylog.html
+++ b/src/activitylog/activitylog.html
@@ -1,1 +1,46 @@
-<!-- activitylog.html -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Extension Activity Monitor</title>
+    <link rel="stylesheet" href="activitylog.css" />
+    <script src="activitylog.js" type="module"></script>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Extension Activity Monitor</h1>
+      <div class="load-file-wrapper">
+        <input id="logInputFile" type="file" accept="application/json" />
+        <button id="loadLogBtn" disabled>Load logs</button>
+      </div>
+      <button id="saveLogBtn">Save logs</button>
+      <div class="notice"></div>
+      <div class="activity-log-wrapper">
+        <h2>Activity Logs</h2>
+        <div class="activity-log-container">
+          <div class="log-table">
+            <table>
+              <tr>
+                <th>Extension Id</th>
+                <th>Timestamp</th>
+                <th>API Type</th>
+                <th>API Name</th>
+                <th>View Type</th>
+              </tr>
+              <tbody></tbody>
+            </table>
+          </div>
+          <div class="show-log-detail-wrapper">
+            <div id="showLogDetails"></div>
+            <div class="close"></div>
+          </div>
+        </div>
+      </div>
+      <div class="load-log-wrapper">
+        <h2>Loaded Logs</h2>
+        <div id="showLoadedLog"></div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/activitylog/activitylog.html
+++ b/src/activitylog/activitylog.html
@@ -29,7 +29,7 @@
               <tbody></tbody>
             </table>
           </div>
-          <div class="show-log-detail-wrapper">
+          <div class="show-log-detail-wrapper" hidden>
             <div id="showLogDetails"></div>
             <div class="close"></div>
           </div>

--- a/src/activitylog/activitylog.html
+++ b/src/activitylog/activitylog.html
@@ -10,10 +10,6 @@
   <body>
     <div class="container">
       <h1>Extension Activity Monitor</h1>
-      <div class="load-file-wrapper">
-        <input id="logInputFile" type="file" accept="application/json" />
-        <button id="loadLogBtn" disabled>Load logs</button>
-      </div>
       <button id="saveLogBtn">Save logs</button>
       <div class="notice"></div>
       <div class="activity-log-wrapper">
@@ -21,13 +17,15 @@
         <div class="activity-log-container">
           <div class="log-table">
             <table>
-              <tr>
-                <th>Extension Id</th>
-                <th>Timestamp</th>
-                <th>API Type</th>
-                <th>API Name</th>
-                <th>View Type</th>
-              </tr>
+              <thead>
+                <tr>
+                  <th>Extension Id</th>
+                  <th>Timestamp</th>
+                  <th>API Type</th>
+                  <th>API Name</th>
+                  <th>View Type</th>
+                </tr>
+              </thead>
               <tbody></tbody>
             </table>
           </div>
@@ -36,10 +34,6 @@
             <div class="close"></div>
           </div>
         </div>
-      </div>
-      <div class="load-log-wrapper">
-        <h2>Loaded Logs</h2>
-        <div id="showLoadedLog"></div>
       </div>
     </div>
   </body>

--- a/src/activitylog/activitylog.js
+++ b/src/activitylog/activitylog.js
@@ -1,5 +1,5 @@
 import ActivityLog from '../lib/ext-activitylog.js';
 
-window.addEventListener('DOMContentLoaded', async () => {
+document.addEventListener('DOMContentLoaded', async () => {
   await new ActivityLog().init();
 });

--- a/src/activitylog/activitylog.js
+++ b/src/activitylog/activitylog.js
@@ -1,1 +1,5 @@
-/* activitylog.js */
+import ActivityLog from '../lib/ext-activitylog.js';
+
+window.addEventListener('DOMContentLoaded', async () => {
+  await new ActivityLog().init();
+});

--- a/src/icons/close.svg
+++ b/src/icons/close.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x-square"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="9" x2="15" y2="15"></line><line x1="15" y1="9" x2="9" y2="15"></line></svg>

--- a/src/lib/ext-activitylog.js
+++ b/src/lib/ext-activitylog.js
@@ -90,9 +90,7 @@ export default class ActivityLog {
           this.closeDetailSidebar();
           break;
         default:
-          throw new Error(
-            `unexpected click event on ${JSON.stringify(event.target.tagName)}`
-          );
+          throw new Error(`unexpected click event on ${event.target.tagName}`);
       }
     } else {
       throw new Error(`wrong event type found ${event.type}`);
@@ -114,7 +112,7 @@ export default class ActivityLog {
   async saveLogs() {
     try {
       await save.saveAsJSON(this.logs);
-      this.setError(false);
+      this.setError(null);
     } catch (error) {
       this.setError(error.message);
     }

--- a/src/lib/ext-activitylog.js
+++ b/src/lib/ext-activitylog.js
@@ -1,0 +1,143 @@
+import { save, load } from '../lib/save-load.js';
+
+export default class ActivityLog {
+  constructor() {
+    this.logs = [];
+    this.loadedLogs = [];
+    this.rowIndex = 0;
+
+    this.loadLogBtn = document.getElementById('loadLogBtn');
+    this.logInputFile = document.getElementById('logInputFile');
+    this.saveLogBtn = document.getElementById('saveLogBtn');
+    this.showLogDetailWrapper = document.querySelector(
+      '.show-log-detail-wrapper'
+    );
+    this.showLogDetails = document.getElementById('showLogDetails');
+    this.showLoadedLog = document.getElementById('showLoadedLog');
+    this.logTableWrapper = document.querySelector('.log-table');
+    this.table = document.querySelector('table');
+    this.notice = document.querySelector('.notice');
+    this.closeBtn = document.querySelector('.close');
+  }
+
+  async getExistingLogs() {
+    const { existingLogs } = await browser.runtime.sendMessage({
+      requestType: 'sendAllLogs',
+      requestTo: 'ext-monitor',
+    });
+    return existingLogs;
+  }
+
+  async loadFile(file) {
+    try {
+      const loadedLogsAsText = await load.loadLogAsText(file);
+      const loadedJSONLogs = JSON.parse(loadedLogsAsText);
+      this.loadedLogs.push(...loadedJSONLogs);
+      // TODO: Display loaded logs in table view
+
+      if (this.notice.textContent.trim().length) {
+        this.notice.textContent = '';
+        this.notice.classList.remove('failure');
+      }
+    } catch (error) {
+      this.notice.textContent = error.message;
+      this.notice.classList.add('failure');
+    }
+  }
+
+  async saveLogs(logs) {
+    try {
+      await save.saveAsJSON(logs);
+
+      if (this.notice.textContent.trim().length) {
+        this.notice.textContent = '';
+        this.notice.classList.remove('failure');
+      }
+    } catch (error) {
+      this.notice.textContent = error.message;
+      this.notice.classList.add('failure');
+    }
+  }
+
+  renderSideBar(logIndex) {
+    const logStringfy = JSON.stringify(this.logs[logIndex]);
+    this.showLogDetails.textContent = logStringfy;
+    this.showLogDetailWrapper.style.display = 'block';
+    this.logTableWrapper.classList.add('width-60');
+  }
+
+  handleEvent(event) {
+    if (event.type === 'click') {
+      const selectedRowIndex = event.target.closest('tr').attributes['index']
+        .value;
+
+      if (selectedRowIndex == null) {
+        return;
+      }
+
+      this.renderSideBar(selectedRowIndex);
+    } else {
+      throw new Error('wrong event type found ' + event.type);
+    }
+  }
+
+  renderNewRow(logs) {
+    for (const log of logs) {
+      const newRow = this.table.insertRow(1);
+      newRow.insertCell(0).textContent = log.id;
+      newRow.insertCell(1).textContent = log.timeStamp;
+      newRow.insertCell(2).textContent = log.type;
+      newRow.insertCell(3).textContent = log.name;
+      newRow.insertCell(4).textContent = log.viewType || 'undefined';
+      newRow.setAttribute('index', this.rowIndex++);
+
+      newRow.addEventListener('click', this);
+      this.logs.push(log);
+    }
+  }
+
+  async init() {
+    const existingLogs = await this.getExistingLogs();
+
+    if (existingLogs.length) {
+      this.renderNewRow(existingLogs);
+    }
+
+    this.saveLogBtn.addEventListener('click', () => {
+      this.saveLogs(this.logs);
+    });
+
+    this.logInputFile.addEventListener('change', () => {
+      this.loadLogBtn.removeAttribute('disabled');
+    });
+
+    this.loadLogBtn.addEventListener('click', () => {
+      if (this.logInputFile.files.length > 0) {
+        this.loadFile(this.logInputFile.files[0]);
+        this.logInputFile.value = '';
+        this.loadLogBtn.setAttribute('disabled', true);
+      }
+    });
+
+    this.closeBtn.addEventListener('click', () => {
+      if (this.showLogDetailWrapper.style.display === 'block') {
+        this.showLogDetailWrapper.style.display = 'none';
+        this.logTableWrapper.classList.remove('width-60');
+      }
+    });
+
+    browser.runtime.onMessage.addListener((message) => {
+      const { requestTo, requestType } = message;
+
+      if (requestTo !== 'activity-log') {
+        return;
+      }
+
+      if (requestType === 'appendLogs') {
+        this.renderNewRow([message.log]);
+      } else {
+        throw new Error('wrong request type found ' + requestType);
+      }
+    });
+  }
+}

--- a/src/lib/ext-activitylog.js
+++ b/src/lib/ext-activitylog.js
@@ -91,23 +91,23 @@ export default class ActivityLog {
           break;
         default:
           throw new Error(
-            `unexpected click event on ${JSON.stringify(event.target)}`
+            `unexpected click event on ${JSON.stringify(event.target.tagName)}`
           );
       }
     } else {
-      throw new Error(`wrong event type found ${JSON.stringify(event.type)}`);
+      throw new Error(`wrong event type found ${event.type}`);
     }
   }
 
   openDetailSidebar(logDetails) {
     const logString = JSON.stringify(logDetails);
     this.showLogDetails.textContent = logString;
-    this.showLogDetailWrapper.style.display = 'block';
+    this.showLogDetailWrapper.removeAttribute('hidden');
     this.logTableWrapper.classList.add('width-60');
   }
 
   closeDetailSidebar() {
-    this.showLogDetailWrapper.style.display = 'none';
+    this.showLogDetailWrapper.setAttribute('hidden', true);
     this.logTableWrapper.classList.remove('width-60');
   }
 

--- a/src/lib/ext-activitylog.js
+++ b/src/lib/ext-activitylog.js
@@ -1,23 +1,44 @@
-import { save, load } from '../lib/save-load.js';
+import { save } from '../lib/save-load.js';
 
 export default class ActivityLog {
   constructor() {
     this.logs = [];
-    this.loadedLogs = [];
-    this.rowIndex = 0;
 
-    this.loadLogBtn = document.getElementById('loadLogBtn');
-    this.logInputFile = document.getElementById('logInputFile');
     this.saveLogBtn = document.getElementById('saveLogBtn');
     this.showLogDetailWrapper = document.querySelector(
       '.show-log-detail-wrapper'
     );
     this.showLogDetails = document.getElementById('showLogDetails');
-    this.showLoadedLog = document.getElementById('showLoadedLog');
     this.logTableWrapper = document.querySelector('.log-table');
-    this.table = document.querySelector('table');
+    this.tableBody = document.querySelector('table tbody');
     this.notice = document.querySelector('.notice');
     this.closeBtn = document.querySelector('.close');
+  }
+
+  async init() {
+    const existingLogs = await this.getExistingLogs();
+
+    if (existingLogs.length) {
+      this.addNewLogs(existingLogs);
+    }
+
+    this.saveLogBtn.addEventListener('click', this);
+    this.closeBtn.addEventListener('click', this);
+    this.tableBody.addEventListener('click', this);
+
+    browser.runtime.onMessage.addListener((message) => {
+      const { requestTo, requestType } = message;
+
+      if (requestTo !== 'activity-log') {
+        return;
+      }
+
+      if (requestType === 'appendLogs') {
+        this.addNewLogs([message.log]);
+      } else {
+        throw new Error(`wrong request type found ${requestType}`);
+      }
+    });
   }
 
   async getExistingLogs() {
@@ -28,116 +49,74 @@ export default class ActivityLog {
     return existingLogs;
   }
 
-  async loadFile(file) {
-    try {
-      const loadedLogsAsText = await load.loadLogAsText(file);
-      const loadedJSONLogs = JSON.parse(loadedLogsAsText);
-      this.loadedLogs.push(...loadedJSONLogs);
-      // TODO: Display loaded logs in table view
-
-      if (this.notice.textContent.trim().length) {
-        this.notice.textContent = '';
-        this.notice.classList.remove('failure');
-      }
-    } catch (error) {
-      this.notice.textContent = error.message;
-      this.notice.classList.add('failure');
-    }
-  }
-
-  async saveLogs(logs) {
-    try {
-      await save.saveAsJSON(logs);
-
-      if (this.notice.textContent.trim().length) {
-        this.notice.textContent = '';
-        this.notice.classList.remove('failure');
-      }
-    } catch (error) {
-      this.notice.textContent = error.message;
-      this.notice.classList.add('failure');
-    }
-  }
-
-  renderSideBar(logIndex) {
-    const logStringfy = JSON.stringify(this.logs[logIndex]);
-    this.showLogDetails.textContent = logStringfy;
-    this.showLogDetailWrapper.style.display = 'block';
-    this.logTableWrapper.classList.add('width-60');
-  }
-
-  handleEvent(event) {
-    if (event.type === 'click') {
-      const selectedRowIndex = event.target.closest('tr').attributes['index']
-        .value;
-
-      if (selectedRowIndex == null) {
-        return;
-      }
-
-      this.renderSideBar(selectedRowIndex);
-    } else {
-      throw new Error('wrong event type found ' + event.type);
-    }
-  }
-
-  renderNewRow(logs) {
+  addNewLogs(logs) {
     for (const log of logs) {
-      const newRow = this.table.insertRow(1);
+      const newRow = this.tableBody.insertRow(-1);
       newRow.insertCell(0).textContent = log.id;
       newRow.insertCell(1).textContent = log.timeStamp;
       newRow.insertCell(2).textContent = log.type;
       newRow.insertCell(3).textContent = log.name;
       newRow.insertCell(4).textContent = log.viewType || 'undefined';
-      newRow.setAttribute('index', this.rowIndex++);
+      newRow._log = log;
 
-      newRow.addEventListener('click', this);
       this.logs.push(log);
     }
   }
 
-  async init() {
-    const existingLogs = await this.getExistingLogs();
-
-    if (existingLogs.length) {
-      this.renderNewRow(existingLogs);
+  setError(errorMessage) {
+    if (errorMessage) {
+      this.notice.textContent = errorMessage;
+      this.notice.classList.add('failure');
+    } else {
+      this.notice.textContent = '';
+      this.notice.classList.remove('failure');
     }
+  }
 
-    this.saveLogBtn.addEventListener('click', () => {
-      this.saveLogs(this.logs);
-    });
+  handleEvent(event) {
+    if (event.type === 'click') {
+      const logDetails = event.target.closest('tr')?._log;
 
-    this.logInputFile.addEventListener('change', () => {
-      this.loadLogBtn.removeAttribute('disabled');
-    });
-
-    this.loadLogBtn.addEventListener('click', () => {
-      if (this.logInputFile.files.length > 0) {
-        this.loadFile(this.logInputFile.files[0]);
-        this.logInputFile.value = '';
-        this.loadLogBtn.setAttribute('disabled', true);
-      }
-    });
-
-    this.closeBtn.addEventListener('click', () => {
-      if (this.showLogDetailWrapper.style.display === 'block') {
-        this.showLogDetailWrapper.style.display = 'none';
-        this.logTableWrapper.classList.remove('width-60');
-      }
-    });
-
-    browser.runtime.onMessage.addListener((message) => {
-      const { requestTo, requestType } = message;
-
-      if (requestTo !== 'activity-log') {
+      if (logDetails) {
+        this.openDetailSidebar(logDetails);
         return;
       }
 
-      if (requestType === 'appendLogs') {
-        this.renderNewRow([message.log]);
-      } else {
-        throw new Error('wrong request type found ' + requestType);
+      switch (event.target) {
+        case this.saveLogBtn:
+          this.saveLogs();
+          break;
+        case this.closeBtn:
+          this.closeDetailSidebar();
+          break;
+        default:
+          throw new Error(
+            `unexpected click event on ${JSON.stringify(event.target)}`
+          );
       }
-    });
+    } else {
+      throw new Error(`wrong event type found ${JSON.stringify(event.type)}`);
+    }
+  }
+
+  openDetailSidebar(logDetails) {
+    const logString = JSON.stringify(logDetails);
+    this.showLogDetails.textContent = logString;
+    this.showLogDetailWrapper.style.display = 'block';
+    this.logTableWrapper.classList.add('width-60');
+  }
+
+  closeDetailSidebar() {
+    this.showLogDetailWrapper.style.display = 'none';
+    this.logTableWrapper.classList.remove('width-60');
+  }
+
+  async saveLogs() {
+    try {
+      await save.saveAsJSON(this.logs);
+      this.setError(false);
+    } catch (error) {
+      this.setError(error.message);
+    }
   }
 }

--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -27,6 +27,7 @@ export default class ExtensionMonitor {
     if (isExtPageOpen) {
       await browser.runtime.sendMessage({
         requestType: 'appendLogs',
+        requestTo: 'activity-log',
         log: details,
       });
     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,7 +8,7 @@
   "author": "Mozilla Add-ons Team",
   "homepage_url": "https://github.com/mozilla/extension-activity-monitor",
 
-  "permissions": ["activityLog", "management", "tabs"],
+  "permissions": ["activityLog", "management", "tabs", "downloads"],
 
   "icons": {
     "48": "icons/eam-48.png"


### PR DESCRIPTION
In current activitylog page (extension page): 
- Display existing logs captured in background at initial loading. (method: `getExistingLogs()`)
- As long as the extension page is not destroyed, every logs captured in background will be passed to the extension page for display. (upon receiving message `eam_updateLogs`, every new log to activityLogs array)
- Logs can be saved as json file.
- ~~Logs can be loaded as json file.~~ (deferred to a separate pull request)

**NOTE**: There is a lot to clean up in the code. For now, it just serves the above purposes. I will clean it up very soon.