### PR TITLE
chore: made prettier compatible with version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-import": "^2.21.2",
     "jest": "^26.0.1",
-    "prettier": "2.0.5",
+    "prettier": "^2.0.5",
     "web-ext": "^4.3.0"
   },
   "webExt": {


### PR DESCRIPTION
Made prettier "compatible with version" rather than using "exact dependency". 
From https://github.com/mozilla/extension-activity-monitor/pull/6/files#r447067689