### PR TITLE
feat: filter option with timestamp in context menu

### DIFF
--- a/src/activitylog/activitylog.css
+++ b/src/activitylog/activitylog.css
@@ -25,7 +25,7 @@
   color: #ffffff;
 }
 
-.filter-wrapper {
+.filter-boxes {
   display: flex;
   margin: 10px 0;
 }

--- a/src/activitylog/activitylog.html
+++ b/src/activitylog/activitylog.html
@@ -12,6 +12,10 @@
     ></script>
     <script
       type="module"
+      src="/lib/web-component/filter-timestamp/filter-timestamp-element.js"
+    ></script>
+    <script
+      type="module"
       src="/lib/web-component/filter-option/filter-option-element.js"
     ></script>
     <script
@@ -28,25 +32,28 @@
       <div class="activity-log-wrapper">
         <h2>Activity Logs</h2>
         <div class="filter-wrapper">
-          <filter-keyword></filter-keyword>
-          <filter-option filter-key="id">
-            Select extensions to filter logs
-          </filter-option>
-          <filter-option
-            filter-key="viewType"
-            title="This filter applies to all log entries except content scripts."
-          >
-            Select view type to filter logs
-          </filter-option>
-          <filter-option filter-key="type">
-            Select api type to filter logs
-          </filter-option>
-          <filter-option
-            filter-key="name"
-            title="This filter only applies to log entries related to API events."
-          >
-            Select api name to filter logs
-          </filter-option>
+          <div class="filter-boxes">
+            <filter-keyword></filter-keyword>
+            <filter-option filter-key="id">
+              Select extensions to filter logs
+            </filter-option>
+            <filter-option
+              filter-key="viewType"
+              title="This filter applies to all log entries except content scripts."
+            >
+              Select view type to filter logs
+            </filter-option>
+            <filter-option filter-key="type">
+              Select api type to filter logs
+            </filter-option>
+            <filter-option
+              filter-key="name"
+              title="This filter only applies to log entries related to API events."
+            >
+              Select api name to filter logs
+            </filter-option>
+          </div>
+          <filter-timestamp></filter-timestamp>
         </div>
         <log-view></log-view>
       </div>
@@ -113,4 +120,27 @@
       </div>
     </template>
   </body>
+
+  <template id="filterTimestampTemplate">
+    <link
+      rel="stylesheet"
+      href="/lib/web-component/filter-timestamp/filter-timestamp.css"
+    />
+    <div class="timestamp-filter-container" hidden>
+      <div class="label">
+        Timestamp Filter Applied
+        <div id="clearBtn" title="Clear timestamp filter"></div>
+      </div>
+      <div class="timestamp-filter-options">
+        <div class="start-time-container">
+          <div class="title">Start Time:</div>
+          <div id="startTimeLabel">From beginning</div>
+        </div>
+        <div class="stop-time-container">
+          <div class="title">Stop Time:</div>
+          <div id="stopTimeLabel">Up to End</div>
+        </div>
+      </div>
+    </div>
+  </template>
 </html>

--- a/src/icons/circle-close.svg
+++ b/src/icons/circle-close.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x-circle"><circle cx="12" cy="12" r="10"></circle><line x1="15" y1="9" x2="9" y2="15"></line><line x1="9" y1="9" x2="15" y2="15"></line></svg>

--- a/src/lib/web-component/filter-timestamp/filter-timestamp-element.js
+++ b/src/lib/web-component/filter-timestamp/filter-timestamp-element.js
@@ -1,0 +1,87 @@
+export class FilterTimestamp extends HTMLElement {
+  constructor() {
+    super();
+    this.timeStamp = null;
+
+    const shadow = this.attachShadow({ mode: 'open' });
+
+    const filterWrapper = document
+      .querySelector('#filterTimestampTemplate')
+      .content.cloneNode(true);
+
+    this.filterContainer = filterWrapper.querySelector(
+      '.timestamp-filter-container'
+    );
+
+    this.startTimeLabel = filterWrapper.querySelector('#startTimeLabel');
+    this.stopTimeLabel = filterWrapper.querySelector('#stopTimeLabel');
+    this.clearBtn = filterWrapper.querySelector('#clearBtn');
+
+    shadow.appendChild(filterWrapper);
+  }
+
+  setFilterRange = (info) => {
+    const selectedEl = browser.menus.getTargetElement(info.targetElementId);
+    const selectedRow = selectedEl.closest('tr');
+
+    if (!selectedRow) {
+      return;
+    }
+
+    // this.timestamp is null when timestamp filter is not applied.
+    if (!this.timeStamp) {
+      this.timeStamp = {};
+    }
+
+    const chosenTimestamp = selectedRow.querySelector('.timestamp').textContent;
+    if (info.menuItemId === 'startTime') {
+      this.timeStamp.start = Date.parse(chosenTimestamp);
+      this.startTimeLabel.textContent = chosenTimestamp;
+    } else if (info.menuItemId === 'stopTime') {
+      this.timeStamp.stop = Date.parse(chosenTimestamp);
+      this.stopTimeLabel.textContent = chosenTimestamp;
+    }
+
+    this.filterContainer.hidden = false;
+    this.dispatchFilterChange();
+  };
+
+  dispatchFilterChange() {
+    const filterDetail = {
+      updateFilter: {
+        timeStamp: this.timeStamp,
+      },
+    };
+
+    this.dispatchEvent(
+      new CustomEvent('filterchange', { detail: filterDetail })
+    );
+  }
+
+  onClearFilter = () => {
+    this.startTimeLabel.textContent = 'From Beginning';
+    this.stopTimeLabel.textContent = 'Up to End';
+    this.filterContainer.hidden = true;
+
+    this.timeStamp = null;
+    this.dispatchFilterChange();
+  };
+
+  onHiddenListener = () => {
+    browser.menus.removeAll();
+  };
+
+  connectedCallback() {
+    browser.menus.onClicked.addListener(this.setFilterRange);
+    browser.menus.onHidden.addListener(this.onHiddenListener);
+    this.clearBtn.addEventListener('click', this.onClearFilter);
+  }
+
+  disconnectedCallback() {
+    browser.menus.onClicked.removeListener(this.setFilterRange);
+    browser.menus.onHidden.removeListener(this.onHiddenListener);
+    this.clearBtn.removeEventListener('click', this.onClearFilter);
+  }
+}
+
+window.customElements.define('filter-timestamp', FilterTimestamp);

--- a/src/lib/web-component/filter-timestamp/filter-timestamp.css
+++ b/src/lib/web-component/filter-timestamp/filter-timestamp.css
@@ -1,0 +1,40 @@
+.timestamp-filter-container .label {
+  width: max-content;
+  display: flex;
+  background: #000;
+  padding: 10px 20px;
+  color: #ffffff;
+  align-items: center;
+}
+
+.timestamp-filter-options {
+  display: flex;
+  justify-content: space-evenly;
+  padding: 5px;
+  border-top: 2px solid #000000;
+  border-left: 2px solid #000000;
+  border-right: 2px solid #000000;
+}
+
+.timestamp-filter-options .title {
+  font-weight: bold;
+}
+
+#clearBtn {
+  cursor: pointer;
+  background: url(/icons/circle-close.svg) no-repeat center center / cover;
+  width: 25px;
+  height: 25px;
+  display: inline-block;
+  margin-left: 15px;
+}
+
+#startTimeLabel,
+#stopTimeLabel {
+  padding-left: 5px;
+}
+
+.start-time-container,
+.stop-time-container {
+  display: flex;
+}

--- a/src/lib/web-component/log-view/log-view-element.js
+++ b/src/lib/web-component/log-view/log-view-element.js
@@ -60,18 +60,6 @@ export class LogView extends HTMLElement {
     this.tableBody.appendChild(rowsFragment);
   }
 
-  openDetailSidebar(logDetails) {
-    const logString = JSON.stringify(logDetails, null, 2);
-    this.logDetails.textContent = logString;
-    this.logTableWrapper.classList.add('width-60');
-    this.logDetailWrapper.hidden = false;
-  }
-
-  closeDetailSidebar() {
-    this.logDetailWrapper.hidden = true;
-    this.logTableWrapper.classList.remove('width-60');
-  }
-
   handleEvent(event) {
     if (event.type === 'click') {
       const logDetails = event.target.closest('tr')?._log;
@@ -84,7 +72,42 @@ export class LogView extends HTMLElement {
       if (event.target === this.closeBtn) {
         this.closeDetailSidebar();
       }
+    } else if (event.type === 'contextmenu') {
+      // This event can only be triggered in table body.
+      browser.menus.overrideContext({});
+      this.createContextMenu();
+      browser.menus.refresh();
     }
+  }
+
+  openDetailSidebar(logDetails) {
+    const logString = JSON.stringify(logDetails);
+    this.logDetails.textContent = logString;
+    this.logTableWrapper.classList.add('width-60');
+    this.logDetailWrapper.hidden = false;
+  }
+
+  closeDetailSidebar() {
+    this.logDetailWrapper.hidden = true;
+    this.logTableWrapper.classList.remove('width-60');
+  }
+
+  createContextMenu() {
+    browser.menus.create({
+      id: 'startTime',
+      title: 'Start from this timestamp',
+      contexts: ['page'],
+      viewTypes: ['tab'],
+      documentUrlPatterns: [location.href],
+    });
+
+    browser.menus.create({
+      id: 'stopTime',
+      title: 'Stop at this timestamp',
+      contexts: ['page'],
+      viewTypes: ['tab'],
+      documentUrlPatterns: [location.href],
+    });
   }
 
   clearTable() {
@@ -93,11 +116,13 @@ export class LogView extends HTMLElement {
 
   connectedCallback() {
     this.tableBody.addEventListener('click', this);
+    this.tableBody.addEventListener('contextmenu', this);
     this.closeBtn.addEventListener('click', this);
   }
 
   disconnectedCallback() {
     this.tableBody.removeEventListener('click', this);
+    this.tableBody.removeEventListener('contextmenu', this);
     this.closeBtn.removeEventListener('click', this);
   }
 }

--- a/src/lib/web-component/log-view/log-view.css
+++ b/src/lib/web-component/log-view/log-view.css
@@ -76,5 +76,5 @@ table tbody tr {
 table td {
   word-wrap: anywhere;
   text-align: center;
-  padding: 5px;
+  padding: 10px 5px;
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,7 +8,14 @@
   "author": "Mozilla Add-ons Team",
   "homepage_url": "https://github.com/mozilla/extension-activity-monitor",
 
-  "permissions": ["activityLog", "management", "tabs", "downloads"],
+  "permissions": [
+    "activityLog",
+    "management",
+    "tabs",
+    "downloads",
+    "menus",
+    "menus.overrideContext"
+  ],
 
   "icons": {
     "48": "icons/eam-48.png"

--- a/tests/ext-activitylog.test.js
+++ b/tests/ext-activitylog.test.js
@@ -29,8 +29,6 @@ function observeChange(element) {
 // This applies for other filter options, such as - view type,
 // api type, api name
 test('show/hide logs associated with extension id that is checked/unchecked from filter option', async () => {
-  document.body.innerHTML = activityLogBody;
-
   expect(window.customElements.get('log-view')).toBe(LogView);
   expect(window.customElements.get('filter-option')).toBe(FilterOption);
 
@@ -41,6 +39,7 @@ test('show/hide logs associated with extension id that is checked/unchecked from
       viewType: 'viewType@test',
       type: 'type@test',
       data: [{ test: 'test1@data' }],
+      timeStamp: new Date(),
     },
     {
       /* renders 2nd row in table */
@@ -48,6 +47,7 @@ test('show/hide logs associated with extension id that is checked/unchecked from
       viewType: 'viewType2@test',
       type: 'type2@test',
       data: [{ test: 'test2@data' }],
+      timeStamp: new Date(),
     },
   ];
 
@@ -64,6 +64,8 @@ test('show/hide logs associated with extension id that is checked/unchecked from
   sendMessage.mockImplementation(() => {
     return Promise.resolve({ existingLogs: [] });
   });
+
+  document.body.innerHTML = activityLogBody;
 
   const { activityLog } = new ActivityLog();
   const extFilterBtn = activityLog.view.extFilter.shadowRoot.querySelector(
@@ -120,6 +122,7 @@ test('show/hide logs associated with extension id that is checked/unchecked from
     viewType: 'randomViewType@test',
     type: 'randomtype@test',
     data: [{ test: 'randomTestData' }],
+    timeStamp: new Date(),
   };
 
   activityLog.handleNewLogs([newLog]);
@@ -142,8 +145,6 @@ test('show/hide logs associated with extension id that is checked/unchecked from
 });
 
 test("keyword search show a row when the given keyword is matched in log's data, otherwise hides the row", async () => {
-  document.body.innerHTML = activityLogBody;
-
   expect(window.customElements.get('filter-keyword')).toBe(FilterKeyword);
 
   const logs = [
@@ -153,6 +154,7 @@ test("keyword search show a row when the given keyword is matched in log's data,
       viewType: 'viewType@test',
       type: 'type@test',
       data: [{ test: 'test1@data' }],
+      timeStamp: new Date(),
     },
     {
       /* renders 2nd row in table */
@@ -160,6 +162,7 @@ test("keyword search show a row when the given keyword is matched in log's data,
       viewType: 'viewType2@test',
       type: 'type2@test',
       data: [{ test: 'matched@data' }],
+      timeStamp: new Date(),
     },
   ];
 
@@ -176,6 +179,8 @@ test("keyword search show a row when the given keyword is matched in log's data,
   sendMessage.mockImplementation(() => {
     return Promise.resolve({ existingLogs: [] });
   });
+
+  document.body.innerHTML = activityLogBody;
 
   const { activityLog } = new ActivityLog();
 
@@ -204,8 +209,6 @@ test("keyword search show a row when the given keyword is matched in log's data,
 });
 
 test('clearing logs from activitylog page', async () => {
-  document.body.innerHTML = activityLogBody;
-
   const logs = [
     {
       /* renders 1st row in table */
@@ -213,6 +216,7 @@ test('clearing logs from activitylog page', async () => {
       viewType: 'viewType@test',
       type: 'type@test',
       data: [{ test: 'test1@data' }],
+      timeStamp: new Date(),
     },
     {
       /* renders 2nd row in table */
@@ -220,6 +224,7 @@ test('clearing logs from activitylog page', async () => {
       viewType: 'viewType2@test',
       type: 'type2@test',
       data: [{ test: 'test2@data' }],
+      timeStamp: new Date(),
     },
   ];
 
@@ -238,6 +243,8 @@ test('clearing logs from activitylog page', async () => {
   sendMessage.mockResolvedValueOnce({ existingLogs: logs });
   sendMessage.mockResolvedValueOnce({ existingLogs: logs });
   sendMessage.mockResolvedValueOnce();
+
+  document.body.innerHTML = activityLogBody;
 
   const { activityLog } = new ActivityLog();
   const clearBackgroundLogsFn = jest.spyOn(activityLog, 'clearBackgroundLogs');


### PR DESCRIPTION
This PR introduces -
- Context menu on table's body. It only shows in the table's body. It has 3 options -
   - Start from this timestamp
   - Stop at this timestamp
   - Clear timestamp filter

### Screenshot
<img width="1257" alt="Screenshot 2020-07-26 at 9 14 15 PM" src="https://user-images.githubusercontent.com/8364578/88482722-00d85900-cf85-11ea-9e93-0c7b627e47c5.png">
