### PR TITLE
feat: load logs from json file

### DIFF
--- a/src/activitylog/activitylog.html
+++ b/src/activitylog/activitylog.html
@@ -27,8 +27,8 @@
         <button id="saveLogBtn">Save logs</button>
         <button id="clearLogBtn">Clear All Logs</button>
         <button id="clearLoadedLogs">Clear All Loaded Logs</button>
-        <div class="notice"></div>
       </div>
+      <div class="notice"></div>
       <div class="activity-log-wrapper">
         <h2>Activity Logs</h2>
         <div class="filter-wrapper">

--- a/src/activitylog/activitylog.html
+++ b/src/activitylog/activitylog.html
@@ -22,9 +22,13 @@
   <body>
     <div class="container">
       <h1>Extension Activity Monitor</h1>
-      <button id="saveLogBtn">Save logs</button>
-      <button id="clearLogBtn">Clear All Logs</button>
-      <div class="notice"></div>
+      <div class="menu-container">
+        <input type="file" name="loadLogFile" accept="application/JSON" />
+        <button id="saveLogBtn">Save logs</button>
+        <button id="clearLogBtn">Clear All Logs</button>
+        <button id="clearLoadedLogs">Clear All Loaded Logs</button>
+        <div class="notice"></div>
+      </div>
       <div class="activity-log-wrapper">
         <h2>Activity Logs</h2>
         <div class="filter-wrapper">

--- a/src/activitylog/activitylog.html
+++ b/src/activitylog/activitylog.html
@@ -26,7 +26,6 @@
         <input type="file" name="loadLogFile" accept="application/JSON" />
         <button id="saveLogBtn">Save logs</button>
         <button id="clearLogBtn">Clear All Logs</button>
-        <button id="clearLoadedLogs">Clear All Loaded Logs</button>
       </div>
       <div class="notice"></div>
       <div class="activity-log-wrapper">

--- a/src/lib/ext-activitylog.js
+++ b/src/lib/ext-activitylog.js
@@ -1,4 +1,5 @@
-import { save } from './save-load.js';
+import { getActivityLogPageURL } from './ext-listen.js';
+import { load, save } from './save-load.js';
 
 class Model {
   constructor() {
@@ -64,8 +65,11 @@ class Model {
 class View {
   constructor() {
     this.logView = document.querySelector('log-view');
+    this.menuContainer = document.querySelector('.menu-container');
     this.clearLogBtn = document.querySelector('#clearLogBtn');
     this.saveLogBtn = document.querySelector('#saveLogBtn');
+    this.loadLogFile = document.querySelector('input[name="loadLogFile"]');
+    this.clearLoadedLogBtn = document.querySelector('#clearLoadedLogs');
     this.notice = document.querySelector('.notice');
 
     this.extFilter = document.querySelector('filter-option[filter-key="id"]');
@@ -79,6 +83,8 @@ class View {
 
     this.clearLogBtn.addEventListener('click', this);
     this.saveLogBtn.addEventListener('click', this);
+    this.loadLogFile.addEventListener('change', this);
+    this.clearLoadedLogBtn.addEventListener('click', this);
   }
 
   setLogFilter(filterFunc) {
@@ -94,9 +100,20 @@ class View {
         case this.clearLogBtn:
           this.clearLogBtn.dispatchEvent(new CustomEvent('clearlog'));
           break;
+        case this.clearLoadedLogBtn:
+          this.clearLoadedLogBtn.dispatchEvent(
+            new CustomEvent('clearloadedlog')
+          );
+          break;
         default:
           throw new Error(`wrong event target - ${event.target.tagName}`);
       }
+    } else if (event.type === 'change' && event.target === this.loadLogFile) {
+      const logFile = event.target.files[0];
+      this.loadLogFile.value = '';
+      this.loadLogFile.dispatchEvent(
+        new CustomEvent('loadlog', { detail: logFile })
+      );
     } else {
       throw new Error(`wrong event type - ${event.type}`);
     }
@@ -137,31 +154,58 @@ class Controller {
   }
 
   async init() {
-    this.view.clearLogBtn.addEventListener('clearlog', this);
-    this.view.saveLogBtn.addEventListener('savelog', this);
     this.view.keywordFilter.addEventListener('filterchange', this);
     this.view.extFilter.addEventListener('filterchange', this);
     this.view.viewTypeFilter.addEventListener('filterchange', this);
     this.view.apiTypeFilter.addEventListener('filterchange', this);
+    const searchParams = window.location.search;
 
-    browser.runtime.onMessage.addListener((message) => {
-      const { requestTo, requestType } = message;
+    if (searchParams.includes('page=loadLog&file=')) {
+      this.view.menuContainer.hidden = true;
 
-      if (requestTo !== 'activity-log') {
+      const fileName = searchParams.substring(
+        searchParams.indexOf('file=') + 5
+      );
+      if (!fileName) {
         return;
       }
 
-      if (requestType === 'appendLogs') {
-        this.handleNewLogs([message.log]);
-      } else {
-        throw new Error(`wrong request type found - ${requestType}`);
+      document.title = `Loaded Logs - ${fileName}`;
+
+      const logs = await browser.runtime.sendMessage({
+        requestType: 'getLoadedLogs',
+        requestTo: 'ext-monitor',
+        detail: { fileName },
+      });
+
+      if (logs.length) {
+        this.handleNewLogs(logs);
       }
-    });
+    } else {
+      this.view.loadLogFile.addEventListener('loadlog', this);
+      this.view.clearLogBtn.addEventListener('clearlog', this);
+      this.view.saveLogBtn.addEventListener('savelog', this);
+      this.view.clearLoadedLogBtn.addEventListener('clearloadedlog', this);
 
-    const existingLogs = await this.getExistingLogs();
+      browser.runtime.onMessage.addListener((message) => {
+        const { requestTo, requestType } = message;
 
-    if (existingLogs.length) {
-      this.handleNewLogs(existingLogs);
+        if (requestTo !== 'activity-log') {
+          return;
+        }
+
+        if (requestType === 'appendLogs') {
+          this.handleNewLogs([message.log]);
+        } else {
+          throw new Error(`wrong request type found - ${requestType}`);
+        }
+      });
+
+      const existingLogs = await this.getExistingLogs();
+
+      if (existingLogs.length) {
+        this.handleNewLogs(existingLogs);
+      }
     }
   }
 
@@ -180,6 +224,9 @@ class Controller {
 
   handleEvent(event) {
     switch (event.type) {
+      case 'loadlog':
+        this.loadLogs(event.detail);
+        break;
       case 'savelog':
         this.saveLogs();
         break;
@@ -189,8 +236,33 @@ class Controller {
       case 'clearlog':
         this.handleClearLogs();
         break;
+      case 'clearloadedlog':
+        this.onClearLoadedLogs();
+        break;
       default:
         throw new Error(`wrong event type found - ${event.type}`);
+    }
+  }
+
+  async loadLogs(file) {
+    try {
+      const logStr = await load.loadLogAsText(file);
+      const logs = JSON.parse(logStr);
+
+      const storedFileName = await browser.runtime.sendMessage({
+        requestTo: 'ext-monitor',
+        requestType: 'loadLogs',
+        detail: { logs, fileName: file.name },
+      });
+      const searchParams = `page=loadLog&file=${storedFileName}`;
+
+      this.view.setError(null);
+
+      browser.tabs.create({
+        url: getActivityLogPageURL(searchParams),
+      });
+    } catch (error) {
+      this.view.setError(error.message);
     }
   }
 
@@ -227,6 +299,13 @@ class Controller {
   async clearBackgroundLogs() {
     await browser.runtime.sendMessage({
       requestType: 'clearLogs',
+      requestTo: 'ext-monitor',
+    });
+  }
+
+  async onClearLoadedLogs() {
+    await browser.runtime.sendMessage({
+      requestType: 'clearLoadedLogs',
       requestTo: 'ext-monitor',
     });
   }

--- a/src/lib/ext-activitylog.js
+++ b/src/lib/ext-activitylog.js
@@ -247,8 +247,14 @@ class Controller {
 
       this.view.setError(null);
 
-      browser.tabs.create({
+      const tab = await browser.tabs.create({
         url: getActivityLogPageURL(searchParams),
+      });
+
+      await browser.runtime.sendMessage({
+        requestTo: 'ext-monitor',
+        requestType: 'setLoadedLogsTabId',
+        detail: { tabId: tab.id, fileName: storedFileName },
       });
     } catch (error) {
       this.view.setError(error.message);

--- a/src/lib/ext-activitylog.js
+++ b/src/lib/ext-activitylog.js
@@ -69,7 +69,6 @@ class View {
     this.clearLogBtn = document.querySelector('#clearLogBtn');
     this.saveLogBtn = document.querySelector('#saveLogBtn');
     this.loadLogFile = document.querySelector('input[name="loadLogFile"]');
-    this.clearLoadedLogBtn = document.querySelector('#clearLoadedLogs');
     this.notice = document.querySelector('.notice');
 
     this.extFilter = document.querySelector('filter-option[filter-key="id"]');
@@ -84,7 +83,6 @@ class View {
     this.clearLogBtn.addEventListener('click', this);
     this.saveLogBtn.addEventListener('click', this);
     this.loadLogFile.addEventListener('change', this);
-    this.clearLoadedLogBtn.addEventListener('click', this);
   }
 
   setLogFilter(filterFunc) {
@@ -99,11 +97,6 @@ class View {
           break;
         case this.clearLogBtn:
           this.clearLogBtn.dispatchEvent(new CustomEvent('clearlog'));
-          break;
-        case this.clearLoadedLogBtn:
-          this.clearLoadedLogBtn.dispatchEvent(
-            new CustomEvent('clearloadedlog')
-          );
           break;
         default:
           throw new Error(`wrong event target - ${event.target.tagName}`);
@@ -185,7 +178,6 @@ class Controller {
       this.view.loadLogFile.addEventListener('loadlog', this);
       this.view.clearLogBtn.addEventListener('clearlog', this);
       this.view.saveLogBtn.addEventListener('savelog', this);
-      this.view.clearLoadedLogBtn.addEventListener('clearloadedlog', this);
 
       browser.runtime.onMessage.addListener((message) => {
         const { requestTo, requestType } = message;
@@ -235,9 +227,6 @@ class Controller {
         break;
       case 'clearlog':
         this.handleClearLogs();
-        break;
-      case 'clearloadedlog':
-        this.onClearLoadedLogs();
         break;
       default:
         throw new Error(`wrong event type found - ${event.type}`);
@@ -299,13 +288,6 @@ class Controller {
   async clearBackgroundLogs() {
     await browser.runtime.sendMessage({
       requestType: 'clearLogs',
-      requestTo: 'ext-monitor',
-    });
-  }
-
-  async onClearLoadedLogs() {
-    await browser.runtime.sendMessage({
-      requestType: 'clearLoadedLogs',
       requestTo: 'ext-monitor',
     });
   }

--- a/src/lib/ext-activitylog.js
+++ b/src/lib/ext-activitylog.js
@@ -1,4 +1,3 @@
-import { getActivityLogPageURL } from './ext-listen.js';
 import { save } from './save-load.js';
 
 class Model {

--- a/src/lib/ext-listen.js
+++ b/src/lib/ext-listen.js
@@ -1,5 +1,7 @@
-export function getActivityLogPageURL() {
-  return browser.runtime.getURL('/activitylog/activitylog.html');
+export function getActivityLogPageURL(searchParams) {
+  return browser.runtime.getURL(
+    `/activitylog/activitylog.html${searchParams ? `?${searchParams}` : ''}`
+  );
 }
 
 export async function getMonitorStatus() {

--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -140,8 +140,8 @@ export default class ExtensionMonitor {
 
   init() {
     this.tabToUrl = {};
-    browser.runtime.onMessage.addListener(this.messageListener);
 
+    browser.runtime.onMessage.addListener(this.messageListener);
     browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
       this.tabToUrl[tabId] = tab.url;
     });

--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -2,10 +2,8 @@ import { getActivityLogPageURL } from './ext-listen.js';
 import { load } from './save-load.js';
 
 export default class ExtensionMonitor {
-  // Map<string, Array>
+  // Map<number, Array>
   loadedLogs = new Map();
-  // Map<number, string>
-  loadedLogsTabIds = new Map();
   logs = [];
   // Map<string, Function>
   extensionMapList = new Map([]);

--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -80,7 +80,6 @@ export default class ExtensionMonitor {
     sendAllLogs: () => ({ existingLogs: this.logs }),
     setLoadedLogs: (detail) => this.setLoadedLogs(detail),
     getLoadedLogs: (detail) => this.getLoadedLogs(detail),
-    clearLoadedLogs: () => this.loadedLogs.clear(),
   };
 
   setLoadedLogs({ fileName, logs }) {
@@ -128,7 +127,24 @@ export default class ExtensionMonitor {
     }
   };
 
+  onRemovedListener = (tabId) => {
+    const url = new URL(this.tabToUrl[tabId]);
+    const searchParams = new URLSearchParams(url.search);
+    const fileName = searchParams.get('file');
+
+    // When we close any loaded Logs tab
+    if (fileName && this.loadedLogs.has(fileName)) {
+      this.loadedLogs.delete(fileName);
+    }
+  };
+
   init() {
+    this.tabToUrl = {};
     browser.runtime.onMessage.addListener(this.messageListener);
+
+    browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+      this.tabToUrl[tabId] = tab.url;
+    });
+    browser.tabs.onRemoved.addListener(this.onRemovedListener);
   }
 }

--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -135,6 +135,7 @@ export default class ExtensionMonitor {
     // When we close any tab which is loaded with logs from a log file.
     if (fileName && this.loadedLogs.has(fileName)) {
       this.loadedLogs.delete(fileName);
+      delete this.tabToUrl[tabId];
     }
   };
 

--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -132,7 +132,7 @@ export default class ExtensionMonitor {
     const searchParams = new URLSearchParams(url.search);
     const fileName = searchParams.get('file');
 
-    // When we close any loaded Logs tab
+    // When we close any tab which is loaded with logs from a log file.
     if (fileName && this.loadedLogs.has(fileName)) {
       this.loadedLogs.delete(fileName);
     }

--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -86,16 +86,14 @@ export default class ExtensionMonitor {
   };
 
   async loadLogs({ file }) {
-    const logStr = await load.loadLogAsText(file);
-    const logs = JSON.parse(logStr);
+    const loadedLogs = await load.loadLogAsJSON(file);
 
     const searchParams = `file=${file.name}`;
-
     const tab = await browser.tabs.create({
       url: getActivityLogPageURL(searchParams),
     });
 
-    this.loadedLogs.set(tab.id, logs);
+    this.loadedLogs.set(tab.id, loadedLogs);
   }
 
   getLoadedLogs({ tabId }) {

--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -126,7 +126,7 @@ export default class ExtensionMonitor {
   };
 
   onRemovedListener = (tabId) => {
-    // When we close any tab which is loaded with logs from a log file.
+    // When we close any tab which was loaded with logs from a log file.
     if (this.loadedLogs.has(tabId)) {
       this.loadedLogs.delete(tabId);
     }

--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -3,7 +3,7 @@ import { load } from './save-load.js';
 
 export default class ExtensionMonitor {
   // Map<number, Array>
-  loadedLogs = new Map();
+  loadedLogsByTabId = new Map();
   logs = [];
   // Map<string, Function>
   extensionMapList = new Map([]);
@@ -91,11 +91,11 @@ export default class ExtensionMonitor {
       url: getActivityLogPageURL(searchParams),
     });
 
-    this.loadedLogs.set(tab.id, loadedLogs);
+    this.loadedLogsByTabId.set(tab.id, loadedLogs);
   }
 
   getLoadedLogs({ tabId }) {
-    const logs = this.loadedLogs.get(tabId);
+    const logs = this.loadedLogsByTabId.get(tabId);
     if (!logs) {
       throw new Error(`No loaded logs found for tab id: ${tabId}`);
     }
@@ -124,9 +124,9 @@ export default class ExtensionMonitor {
   };
 
   onRemovedListener = (tabId) => {
-    // When we close any tab which was loaded with logs from a log file.
-    if (this.loadedLogs.has(tabId)) {
-      this.loadedLogs.delete(tabId);
+    // Remove the loaded logs related to the closed tab
+    if (this.loadedLogsByTabId.has(tabId)) {
+      this.loadedLogsByTabId.delete(tabId);
     }
   };
 

--- a/src/lib/save-load.js
+++ b/src/lib/save-load.js
@@ -12,8 +12,9 @@ export const load = {
     });
   },
 
-  async loadLogAsText(logFile) {
-    return await this.readFile(logFile);
+  async loadLogAsJSON(logFile) {
+    const logStr = await this.readFile(logFile);
+    return JSON.parse(logStr);
   },
 };
 

--- a/tests/ext-monitor.test.js
+++ b/tests/ext-monitor.test.js
@@ -243,10 +243,14 @@ test('listeners are registered at initialization', () => {
   };
 
   const extMonitor = new ExtensionMonitor();
+  const messageListenerFn = jest.spyOn(extMonitor, 'messageListener');
+  const onRemovedListenerFn = jest.spyOn(extMonitor, 'onRemovedListener');
+
   extMonitor.init();
 
-  // runtime.onMessage.addListener and tabs.onRemoved.addListener are called.
   expect(addListener).toHaveBeenCalledTimes(2);
+  expect(addListener).toHaveBeenNthCalledWith(1, messageListenerFn);
+  expect(addListener).toHaveBeenNthCalledWith(2, onRemovedListenerFn);
 });
 
 test('empty log array is found after clearing logs', async () => {

--- a/tests/ext-monitor.test.js
+++ b/tests/ext-monitor.test.js
@@ -234,17 +234,19 @@ describe('messageListeners functionalities test', () => {
   });
 });
 
-test('onMessage listener is registered at initialization', () => {
+test('listeners are registered at initialization', () => {
   const addListener = jest.fn().mockResolvedValue();
 
   window.browser = {
     runtime: { onMessage: { addListener } },
+    tabs: { onRemoved: { addListener } },
   };
 
   const extMonitor = new ExtensionMonitor();
   extMonitor.init();
 
-  expect(addListener).toHaveBeenCalled();
+  // runtime.onMessage.addListener and tabs.onRemoved.addListener are called.
+  expect(addListener).toHaveBeenCalledTimes(2);
 });
 
 test('empty log array is found after clearing logs', async () => {

--- a/tests/ext-monitor.test.js
+++ b/tests/ext-monitor.test.js
@@ -235,11 +235,12 @@ describe('messageListeners functionalities test', () => {
 });
 
 test('listeners are registered at initialization', () => {
-  const addListener = jest.fn().mockResolvedValue();
+  const runtimeMessageAddListener = jest.fn();
+  const tabsRemovedAddListener = jest.fn();
 
   window.browser = {
-    runtime: { onMessage: { addListener } },
-    tabs: { onRemoved: { addListener } },
+    runtime: { onMessage: { addListener: runtimeMessageAddListener } },
+    tabs: { onRemoved: { addListener: tabsRemovedAddListener } },
   };
 
   const extMonitor = new ExtensionMonitor();
@@ -248,9 +249,8 @@ test('listeners are registered at initialization', () => {
 
   extMonitor.init();
 
-  expect(addListener).toHaveBeenCalledTimes(2);
-  expect(addListener).toHaveBeenNthCalledWith(1, messageListenerFn);
-  expect(addListener).toHaveBeenNthCalledWith(2, onRemovedListenerFn);
+  expect(runtimeMessageAddListener).toHaveBeenCalledWith(messageListenerFn);
+  expect(tabsRemovedAddListener).toHaveBeenCalledWith(onRemovedListenerFn);
 });
 
 test('empty log array is found after clearing logs', async () => {

--- a/tests/save-load.test.js
+++ b/tests/save-load.test.js
@@ -2,13 +2,14 @@ import { load, save } from '../src/lib/save-load';
 
 describe('load file functionalities', () => {
   test('load data from a file', async () => {
-    const file = JSON.stringify([{ prop: 'log' }]);
+    const logs = [{ prop: 'log' }];
+    const file = JSON.stringify(logs);
     const blob = new Blob([file], {
       type: 'application/json',
     });
 
-    const loadedLogs = load.loadLogAsText(blob);
-    await expect(loadedLogs).resolves.toBe(file);
+    const loadedLogs = load.loadLogAsJSON(blob);
+    await expect(loadedLogs).resolves.toMatchObject(logs);
   });
 
   test('throws error while reading file', async () => {
@@ -26,7 +27,7 @@ describe('load file functionalities', () => {
       this.onerror();
     });
 
-    const loadedLogs = load.loadLogAsText(blob);
+    const loadedLogs = load.loadLogAsJSON(blob);
     await expect(loadedLogs).rejects.toThrowError('read-error');
 
     readAsTextFn.mockRestore();


### PR DESCRIPTION
Fixes #25 
### The following is done:
- Load log file (json) from local machine
- Loaded logs will be shown in `log-view` opening a new tab with the following parameter at the end of url: `?page=loadLog&file=filename.json`.
- The loaded logs page has a page title set to `Loaded Logs - fileName.json`. This will help to identify it's a loaded logs page.
- There is a button named "Clear All Loaded Logs" which clears all the loaded logs. User can access their loaded logs at any time with respective parameters in URL until they clear the loaded logs.
- [`menu-container`](https://github.com/mozilla/extension-activity-monitor/pull/28/files#diff-f63ec68852d55aaede19b261da7a08d6R25) is hidden in `load log` page. That means, there will be no option to save, clear, load logs and clear loaded logs in a loaded logs page.

### Screenshot
<img width="1280" alt="Screenshot 2020-08-02 at 10 14 24 PM" src="https://user-images.githubusercontent.com/8364578/89127181-8c199780-d50d-11ea-9c5e-f37355fb70b4.png">
