### PR TITLE
feat: ActivityLog DevTools panel added and Filter by tabId is supported

### DIFF
--- a/src/activitylog/activitylog.html
+++ b/src/activitylog/activitylog.html
@@ -33,7 +33,7 @@
       </div>
       <div class="notice"></div>
       <div class="activity-log-wrapper">
-        <h2>Activity Logs</h2>
+        <h2 class="log-heading">Activity Logs</h2>
         <div class="filter-wrapper">
           <div class="filter-boxes">
             <filter-keyword></filter-keyword>

--- a/src/devtools/devtools.html
+++ b/src/devtools/devtools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <script src="devtools.js"></script>
+  </body>
+</html>

--- a/src/devtools/devtools.html
+++ b/src/devtools/devtools.html
@@ -2,8 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <script defer src="devtools.js"></script>
   </head>
-  <body>
-    <script src="devtools.js"></script>
-  </body>
 </html>

--- a/src/devtools/devtools.js
+++ b/src/devtools/devtools.js
@@ -1,0 +1,22 @@
+const currentTabId = browser.devtools.inspectedWindow.tabId;
+
+browser.devtools.panels
+  .create(
+    'Extension Activity',
+    '/icons/eam-48.png',
+    `/activitylog/activitylog.html?filterTabId=${currentTabId}`
+  )
+  .then((newPanel) => {
+    newPanel.onShown.addListener(() => {
+      browser.runtime.sendMessage({
+        requestTo: 'ext-monitor',
+        requestType: 'devToolsPanelShown',
+      });
+    });
+    newPanel.onHidden.addListener(() => {
+      browser.runtime.sendMessage({
+        requestTo: 'ext-monitor',
+        requestType: 'devToolsPanelHidden',
+      });
+    });
+  });

--- a/src/devtools/devtools.js
+++ b/src/devtools/devtools.js
@@ -1,22 +1,24 @@
-const currentTabId = browser.devtools.inspectedWindow.tabId;
+const tabId = browser.devtools.inspectedWindow.tabId;
 
 browser.devtools.panels
   .create(
     'Extension Activity',
     '/icons/eam-48.png',
-    `/activitylog/activitylog.html?filterTabId=${currentTabId}`
+    `/activitylog/activitylog.html?filterTabId=${tabId}`
   )
   .then((newPanel) => {
     newPanel.onShown.addListener(() => {
       browser.runtime.sendMessage({
         requestTo: 'ext-monitor',
-        requestType: 'devToolsPanelShown',
+        requestType: 'addPanelTabId',
+        requestParams: { tabId },
       });
     });
     newPanel.onHidden.addListener(() => {
       browser.runtime.sendMessage({
         requestTo: 'ext-monitor',
-        requestType: 'devToolsPanelHidden',
+        requestType: 'deletePanelTabId',
+        requestParams: { tabId },
       });
     });
   });

--- a/src/devtools/devtools.js
+++ b/src/devtools/devtools.js
@@ -1,24 +1,7 @@
 const tabId = browser.devtools.inspectedWindow.tabId;
 
-browser.devtools.panels
-  .create(
-    'Extension Activity',
-    '/icons/eam-48.png',
-    `/activitylog/activitylog.html?filterTabId=${tabId}`
-  )
-  .then((newPanel) => {
-    newPanel.onShown.addListener(() => {
-      browser.runtime.sendMessage({
-        requestTo: 'ext-monitor',
-        requestType: 'addPanelTabId',
-        requestParams: { tabId },
-      });
-    });
-    newPanel.onHidden.addListener(() => {
-      browser.runtime.sendMessage({
-        requestTo: 'ext-monitor',
-        requestType: 'deletePanelTabId',
-        requestParams: { tabId },
-      });
-    });
-  });
+browser.devtools.panels.create(
+  'Extension Activity',
+  '/icons/eam-48.png',
+  `/activitylog/activitylog.html?filterTabId=${tabId}`
+);

--- a/src/lib/ext-activitylog.js
+++ b/src/lib/ext-activitylog.js
@@ -198,8 +198,8 @@ class View {
     this.logView.clearTable();
   }
 
-  updateLogHeading(newHeading) {
-    this.logHeading.textContent = newHeading;
+  renderView({ filterTabId }) {
+    this.logHeading.textContent = `Activity Logs Filtered By Tab Id: ${filterTabId}`;
   }
 }
 
@@ -272,9 +272,7 @@ class Controller {
       }
 
       if (filterTabId) {
-        this.view.updateLogHeading(
-          `Activity Logs Filtered By Tab Id: ${filterTabId}`
-        );
+        this.view.renderView({ filterTabId });
 
         const filterDetail = {
           updateFilter: { tabId: filterTabId },

--- a/src/lib/ext-activitylog.js
+++ b/src/lib/ext-activitylog.js
@@ -100,7 +100,7 @@ class Model {
   }
 
   matchFilterTabId({ tabId }) {
-    if (this.filter.tabId === null) {
+    if (this.filter.tabId == null) {
       return true;
     }
 
@@ -197,6 +197,10 @@ class View {
   clearTable() {
     this.logView.clearTable();
   }
+
+  updateLogHeading(newHeading) {
+    this.logHeading.textContent = newHeading;
+  }
 }
 
 class Controller {
@@ -268,7 +272,9 @@ class Controller {
       }
 
       if (filterTabId) {
-        this.view.logHeading.textContent = `${this.view.logHeading.textContent} Filtered By Tab Id: ${filterTabId}`;
+        this.view.updateLogHeading(
+          `Activity Logs Filtered By Tab Id: ${filterTabId}`
+        );
 
         const filterDetail = {
           updateFilter: { tabId: filterTabId },
@@ -325,7 +331,7 @@ class Controller {
 
   async saveLogs() {
     try {
-      await save.saveAsJSON(this.model.logs);
+      await save.saveAsJSON();
       this.view.setError(null);
     } catch (error) {
       this.view.setError(error.message);

--- a/src/lib/ext-activitylog.js
+++ b/src/lib/ext-activitylog.js
@@ -100,15 +100,11 @@ class Model {
   }
 
   matchFilterTabId({ tabId }) {
-    if (!this.filter.tabId) {
+    if (this.filter.tabId === null) {
       return true;
     }
 
-    if (tabId && tabId === this.filter.tabId) {
-      return true;
-    }
-
-    return false;
+    return this.filter.tabId === tabId;
   }
 
   clearLogs() {

--- a/src/lib/ext-activitylog.js
+++ b/src/lib/ext-activitylog.js
@@ -242,6 +242,7 @@ class Controller {
         this.handleNewLogs(logs);
       }
     } else {
+      browser.runtime.connect({ name: 'monitor-realtime-logs' });
       browser.runtime.onMessage.addListener((message) => {
         const { requestTo, requestType } = message;
 

--- a/src/lib/ext-activitylog.js
+++ b/src/lib/ext-activitylog.js
@@ -242,6 +242,10 @@ class Controller {
         this.handleNewLogs(logs);
       }
     } else {
+      this.view.loadLogFile.addEventListener('loadlog', this);
+      this.view.clearLogBtn.addEventListener('clearlog', this);
+      this.view.saveLogBtn.addEventListener('savelog', this);
+
       browser.runtime.connect({ name: 'monitor-realtime-logs' });
       browser.runtime.onMessage.addListener((message) => {
         const { requestTo, requestType } = message;
@@ -272,10 +276,6 @@ class Controller {
 
         this.onFilterChange(filterDetail);
       }
-
-      this.view.loadLogFile.addEventListener('loadlog', this);
-      this.view.clearLogBtn.addEventListener('clearlog', this);
-      this.view.saveLogBtn.addEventListener('savelog', this);
     }
   }
 

--- a/src/lib/ext-activitylog.js
+++ b/src/lib/ext-activitylog.js
@@ -198,7 +198,7 @@ class View {
     this.logView.clearTable();
   }
 
-  renderView({ filterTabId }) {
+  renderHeading({ filterTabId }) {
     this.logHeading.textContent = `Activity Logs Filtered By Tab Id: ${filterTabId}`;
   }
 }
@@ -272,7 +272,7 @@ class Controller {
       }
 
       if (filterTabId) {
-        this.view.renderView({ filterTabId });
+        this.view.renderHeading({ filterTabId });
 
         const filterDetail = {
           updateFilter: { tabId: filterTabId },

--- a/src/lib/ext-activitylog.js
+++ b/src/lib/ext-activitylog.js
@@ -270,7 +270,6 @@ class Controller {
         };
 
         this.onFilterChange(filterDetail);
-        return;
       }
 
       this.view.loadLogFile.addEventListener('loadlog', this);

--- a/src/lib/ext-activitylog.js
+++ b/src/lib/ext-activitylog.js
@@ -120,6 +120,7 @@ class View {
     this.saveLogBtn = document.querySelector('#saveLogBtn');
     this.loadLogFile = document.querySelector('input[name="loadLogFile"]');
     this.notice = document.querySelector('.notice');
+    this.logHeading = document.querySelector('.log-heading');
 
     this.extFilter = document.querySelector('filter-option[filter-key="id"]');
     this.viewTypeFilter = document.querySelector(
@@ -262,9 +263,7 @@ class Controller {
       }
 
       if (filterTabId) {
-        // currently menu container is hidden when activity log page is
-        // filtered by tab id
-        this.view.menuContainer.hidden = true;
+        this.view.logHeading.textContent = `${this.view.logHeading.textContent} Filtered By Tab Id: ${filterTabId}`;
 
         const filterDetail = {
           updateFilter: { tabId: filterTabId },

--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -20,20 +20,10 @@ export default class ExtensionMonitor {
     });
   }
 
-  async isActivityLogPageOpen() {
-    const activitylogPage = getActivityLogPageURL();
-    const tab = await browser.tabs.query({
-      url: [activitylogPage, `${activitylogPage}?filterTabId=*`],
-    });
-
-    return tab.length > 0;
-  }
-
   // If the Activity Log page is open, each logs will be send to
   // Activity Log page (as soon as it is encountered).
   async sendLogs(details) {
-    const isExtPageOpen = await this.isActivityLogPageOpen();
-    if (isExtPageOpen || this.activityLogPorts.size) {
+    if (this.activityLogPorts.size) {
       await browser.runtime.sendMessage({
         requestType: 'appendLogs',
         requestTo: 'activity-log',

--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -21,8 +21,9 @@ export default class ExtensionMonitor {
   }
 
   async isActivityLogPageOpen() {
+    const activitylogPage = getActivityLogPageURL();
     const tab = await browser.tabs.query({
-      url: getActivityLogPageURL(),
+      url: [activitylogPage, `${activitylogPage}?filterTabId=*`],
     });
 
     return tab.length > 0;

--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -105,7 +105,7 @@ export default class ExtensionMonitor {
     sendAllLogs: () => ({ existingLogs: this.logs }),
     loadLogs: (requestParams) => this.loadLogs(requestParams),
     getLoadedLogs: (requestParams) => this.getLoadedLogs(requestParams),
-    saveLogs: (requestParams) => this.saveLogs(requestParams),
+    saveLogs: () => this.saveLogs(),
   };
 
   async loadLogs({ file }) {
@@ -127,7 +127,11 @@ export default class ExtensionMonitor {
     return logs;
   }
 
-  async saveLogs({ blob, filename }) {
+  async saveLogs() {
+    const blob = new Blob([JSON.stringify(this.logs)], {
+      type: 'application/json',
+    });
+
     const url = URL.createObjectURL(blob);
     let downloadId = null;
     let listener;
@@ -148,7 +152,7 @@ export default class ExtensionMonitor {
     try {
       downloadId = await browser.downloads.download({
         url,
-        filename,
+        filename: 'activitylogs.json',
       });
       return await downloadDonePromise;
     } finally {

--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -115,8 +115,6 @@ export default class ExtensionMonitor {
     sendAllLogs: () => ({ existingLogs: this.logs }),
     loadLogs: (requestParams) => this.loadLogs(requestParams),
     getLoadedLogs: (requestParams) => this.getLoadedLogs(requestParams),
-    addPanelTabId: ({ tabId }) => this.devToolsPanelTabIds.add(tabId),
-    deletePanelTabId: ({ tabId }) => this.devToolsPanelTabIds.delete(tabId),
     saveLogs: (requestParams) => this.saveLogs(requestParams),
   };
 

--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -21,9 +21,8 @@ export default class ExtensionMonitor {
   }
 
   async isActivityLogPageOpen() {
-    const activitylogPage = getActivityLogPageURL();
     const tab = await browser.tabs.query({
-      url: [activitylogPage],
+      url: getActivityLogPageURL(),
     });
 
     return tab.length > 0;

--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -8,6 +8,8 @@ export default class ExtensionMonitor {
   // Map<string, Function>
   extensionMapList = new Map([]);
 
+  isDevToolPanelOpen = false;
+
   async getAllExtensions() {
     const extensions = await browser.management.getAll();
     return extensions.filter((extension) => {
@@ -18,9 +20,15 @@ export default class ExtensionMonitor {
   }
 
   async isActivityLogPageOpen() {
+    const activitylogPage = getActivityLogPageURL();
+    if (this.isDevToolPanelOpen) {
+      return true;
+    }
+
     const tab = await browser.tabs.query({
-      url: getActivityLogPageURL(),
+      url: [activitylogPage, `${activitylogPage}?*`],
     });
+
     return tab.length > 0;
   }
 
@@ -110,6 +118,8 @@ export default class ExtensionMonitor {
     sendAllLogs: () => ({ existingLogs: this.logs }),
     loadLogs: (requestParams) => this.loadLogs(requestParams),
     getLoadedLogs: (requestParams) => this.getLoadedLogs(requestParams),
+    devToolsPanelShown: () => (this.isDevToolPanelOpen = true),
+    devToolsPanelHidden: () => (this.isDevToolPanelOpen = false),
   };
 
   async loadLogs({ file }) {

--- a/src/lib/save-load.js
+++ b/src/lib/save-load.js
@@ -19,41 +19,15 @@ export const load = {
 };
 
 export const save = {
-  async downloadFile(blob, filename) {
-    const url = URL.createObjectURL(blob);
-    let downloadId = null;
-    let listener;
-
-    const downloadDonePromise = new Promise((resolve, reject) => {
-      listener = (result) => {
-        if (result.state.current === 'complete' && result.id === downloadId) {
-          resolve();
-        }
-        if (result.error) {
-          reject(new Error(result.error));
-        }
-      };
-
-      browser.downloads.onChanged.addListener(listener);
-    });
-
-    try {
-      downloadId = await browser.downloads.download({
-        url,
-        filename,
-      });
-      return await downloadDonePromise;
-    } finally {
-      URL.revokeObjectURL(url);
-      browser.downloads.onChanged.removeListener(listener);
-    }
-  },
-
   saveAsJSON(logs) {
     const blob = new Blob([JSON.stringify(logs)], {
       type: 'application/json',
     });
 
-    return this.downloadFile(blob, 'activitylogs.json');
+    return browser.runtime.sendMessage({
+      requestTo: 'ext-monitor',
+      requestType: 'saveLogs',
+      requestParams: { blob, filename: 'activitylogs.json' },
+    });
   },
 };

--- a/src/lib/save-load.js
+++ b/src/lib/save-load.js
@@ -19,15 +19,10 @@ export const load = {
 };
 
 export const save = {
-  saveAsJSON(logs) {
-    const blob = new Blob([JSON.stringify(logs)], {
-      type: 'application/json',
-    });
-
+  saveAsJSON() {
     return browser.runtime.sendMessage({
       requestTo: 'ext-monitor',
       requestType: 'saveLogs',
-      requestParams: { blob, filename: 'activitylogs.json' },
     });
   },
 };

--- a/src/lib/web-component/filter-timestamp/filter-timestamp-element.js
+++ b/src/lib/web-component/filter-timestamp/filter-timestamp-element.js
@@ -107,13 +107,7 @@ export class FilterTimestamp extends HTMLElement {
   }
 
   connectedCallback() {
-    const searchParams = new URLSearchParams(
-      document.location.search.substring(1)
-    );
-
-    const filterTabId = searchParams.get('filterTabId');
-    // context menu doesn't work on devtool_page
-    if (filterTabId) {
+    if (!browser.menus?.onClicked) {
       return;
     }
 

--- a/src/lib/web-component/filter-timestamp/filter-timestamp-element.js
+++ b/src/lib/web-component/filter-timestamp/filter-timestamp-element.js
@@ -107,7 +107,8 @@ export class FilterTimestamp extends HTMLElement {
   }
 
   connectedCallback() {
-    if (!browser.menus?.onClicked) {
+    // issue #43: context menu doesn't work on devtool_page
+    if (!browser.menus?.onClicked || !browser.menus?.onHidden) {
       return;
     }
 

--- a/src/lib/web-component/filter-timestamp/filter-timestamp-element.js
+++ b/src/lib/web-component/filter-timestamp/filter-timestamp-element.js
@@ -107,7 +107,8 @@ export class FilterTimestamp extends HTMLElement {
   }
 
   connectedCallback() {
-    // issue #43: context menu doesn't work on devtool_page
+    // context menu doesn't work on devtool_page
+    // see: https://github.com/mozilla/extension-activity-monitor/issues/43
     if (!browser.menus?.onClicked || !browser.menus?.onHidden) {
       return;
     }

--- a/src/lib/web-component/filter-timestamp/filter-timestamp-element.js
+++ b/src/lib/web-component/filter-timestamp/filter-timestamp-element.js
@@ -107,6 +107,16 @@ export class FilterTimestamp extends HTMLElement {
   }
 
   connectedCallback() {
+    const searchParams = new URLSearchParams(
+      document.location.search.substring(1)
+    );
+
+    const filterTabId = searchParams.get('filterTabId');
+    // context menu doesn't work on devtool_page
+    if (filterTabId) {
+      return;
+    }
+
     browser.menus.onClicked.addListener(this.setFilterRange);
     browser.menus.onHidden.addListener(this.onHiddenListener);
     this.filterContainer.addEventListener('click', this);

--- a/src/lib/web-component/log-view/log-view-element.js
+++ b/src/lib/web-component/log-view/log-view-element.js
@@ -118,7 +118,8 @@ export class LogView extends HTMLElement {
     this.tableBody.addEventListener('click', this);
     this.closeBtn.addEventListener('click', this);
 
-    // issue #43: context menu doesn't work on devtool_page
+    // context menu doesn't work on devtool_page
+    // see: https://github.com/mozilla/extension-activity-monitor/issues/43
     if (browser.menus?.overrideContext) {
       this.tableBody.addEventListener('contextmenu', this);
     }

--- a/src/lib/web-component/log-view/log-view-element.js
+++ b/src/lib/web-component/log-view/log-view-element.js
@@ -115,8 +115,17 @@ export class LogView extends HTMLElement {
   }
 
   connectedCallback() {
+    const searchParams = new URLSearchParams(
+      document.location.search.substring(1)
+    );
+
+    const filterTabId = searchParams.get('filterTabId');
+    // context menu doesn't work on devtool_page
+    if (!filterTabId) {
+      this.tableBody.addEventListener('contextmenu', this);
+    }
+
     this.tableBody.addEventListener('click', this);
-    this.tableBody.addEventListener('contextmenu', this);
     this.closeBtn.addEventListener('click', this);
   }
 

--- a/src/lib/web-component/log-view/log-view-element.js
+++ b/src/lib/web-component/log-view/log-view-element.js
@@ -117,6 +117,8 @@ export class LogView extends HTMLElement {
   connectedCallback() {
     this.tableBody.addEventListener('click', this);
     this.closeBtn.addEventListener('click', this);
+
+    // issue #43: context menu doesn't work on devtool_page
     if (browser.menus?.overrideContext) {
       this.tableBody.addEventListener('contextmenu', this);
     }

--- a/src/lib/web-component/log-view/log-view-element.js
+++ b/src/lib/web-component/log-view/log-view-element.js
@@ -115,18 +115,11 @@ export class LogView extends HTMLElement {
   }
 
   connectedCallback() {
-    const searchParams = new URLSearchParams(
-      document.location.search.substring(1)
-    );
-
-    const filterTabId = searchParams.get('filterTabId');
-    // context menu doesn't work on devtool_page
-    if (!filterTabId) {
-      this.tableBody.addEventListener('contextmenu', this);
-    }
-
     this.tableBody.addEventListener('click', this);
     this.closeBtn.addEventListener('click', this);
+    if (browser.menus?.overrideContext) {
+      this.tableBody.addEventListener('contextmenu', this);
+    }
   }
 
   disconnectedCallback() {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,7 +11,6 @@
   "permissions": [
     "activityLog",
     "management",
-    "tabs",
     "downloads",
     "menus",
     "menus.overrideContext"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,5 +28,7 @@
   "browser_action": {
     "default_title": "EAM Popup",
     "default_popup": "popup/popup.html"
-  }
+  },
+
+  "devtools_page": "devtools/devtools.html"
 }

--- a/tests/ext-activitylog.test.js
+++ b/tests/ext-activitylog.test.js
@@ -53,11 +53,13 @@ test('show/hide logs associated with extension id that is checked/unchecked from
 
   const addListener = jest.fn();
   const sendMessage = jest.fn();
+  const connect = jest.fn();
 
   window.browser = {
     runtime: {
       onMessage: { addListener },
       sendMessage,
+      connect,
     },
   };
 
@@ -168,11 +170,13 @@ test("keyword search show a row when the given keyword is matched in log's data,
 
   const addListener = jest.fn();
   const sendMessage = jest.fn();
+  const connect = jest.fn();
 
   window.browser = {
     runtime: {
       onMessage: { addListener },
       sendMessage,
+      connect,
     },
   };
 
@@ -230,11 +234,13 @@ test('clearing logs from activitylog page', async () => {
 
   const addListener = jest.fn();
   const sendMessage = jest.fn();
+  const connect = jest.fn();
 
   window.browser = {
     runtime: {
       onMessage: { addListener },
       sendMessage,
+      connect,
     },
   };
 

--- a/tests/ext-monitor.test.js
+++ b/tests/ext-monitor.test.js
@@ -251,7 +251,6 @@ test('send logs to extension page if it is opened, as well as storing logs in ba
 
   window.browser = {
     runtime: { getURL, sendMessage },
-    tabs: { query },
   };
 
   const extMonitor = new ExtensionMonitor();
@@ -266,7 +265,11 @@ test('send logs to extension page if it is opened, as well as storing logs in ba
   expect(extMonitor.logs).toMatchObject([log1]);
   expect(sendMessage).not.toHaveBeenCalled();
 
-  // extension page is open
+  // extension page exist when activityLogPorts is not empty
+  // activityLogPorts contains port objects from runtime.onConnect
+  const port = { port: 'extension-page-open' };
+  extMonitor.activityLogPorts.add(port);
+
   listener = extMonitor.createLogListener();
   await listener(log2);
 

--- a/tests/ext-monitor.test.js
+++ b/tests/ext-monitor.test.js
@@ -15,7 +15,11 @@ test('getAllExtensions should return all extensions but themes and self', async 
 
   window.browser = {
     management: { getAll },
-    runtime: { onMessage: { addListener }, id: selfExt.id },
+    runtime: {
+      onMessage: { addListener },
+      id: selfExt.id,
+      onConnect: { addListener },
+    },
     tabs: { onRemoved: { addListener } },
   };
 

--- a/tests/ext-monitor.test.js
+++ b/tests/ext-monitor.test.js
@@ -359,18 +359,23 @@ describe('messageListeners functionalities test', () => {
 test('listeners are registered at initialization', () => {
   const runtimeMessageAddListener = jest.fn();
   const tabsRemovedAddListener = jest.fn();
+  const onConnectAddListener = jest.fn();
 
   window.browser = {
-    runtime: { onMessage: { addListener: runtimeMessageAddListener } },
+    runtime: {
+      onMessage: { addListener: runtimeMessageAddListener },
+      onConnect: { addListener: onConnectAddListener },
+    },
     tabs: { onRemoved: { addListener: tabsRemovedAddListener } },
   };
 
   const extMonitor = new ExtensionMonitor();
+  const onConnectListenerFn = jest.spyOn(extMonitor, 'onConnectListener');
   const messageListenerFn = jest.spyOn(extMonitor, 'messageListener');
   const onRemovedListenerFn = jest.spyOn(extMonitor, 'onRemovedListener');
 
   extMonitor.init();
-
+  expect(onConnectAddListener).toHaveBeenCalledWith(onConnectListenerFn);
   expect(runtimeMessageAddListener).toHaveBeenCalledWith(messageListenerFn);
   expect(tabsRemovedAddListener).toHaveBeenCalledWith(onRemovedListenerFn);
 });

--- a/tests/ext-monitor.test.js
+++ b/tests/ext-monitor.test.js
@@ -435,18 +435,12 @@ test('saveLogs function should call download API to save logs', async () => {
     return Promise.resolve(id);
   });
 
-  const logs = [{ prop1: 'log1' }];
-  const blob = new Blob([JSON.stringify(logs)], {
-    type: 'application/json',
-  });
-
   const extMonitor = new ExtensionMonitor();
   const saveLogsFn = jest.spyOn(extMonitor, 'saveLogs');
 
   const saveLogPromise = extMonitor.messageListener({
     requestTo: 'ext-monitor',
     requestType: 'saveLogs',
-    requestParams: { blob, filename: 'activitylogs.json' },
   });
 
   await expect(saveLogPromise).resolves.toBeUndefined();
@@ -505,15 +499,9 @@ test('saveLogs function should return error message if error is encountered', as
     return Promise.resolve(1);
   });
 
-  const logs = [{ prop1: 'log1' }];
-  const blob = new Blob([JSON.stringify(logs)], {
-    type: 'application/json',
-  });
-
   const saveLogPromise = extMonitor.messageListener({
     requestTo: 'ext-monitor',
     requestType: 'saveLogs',
-    requestParams: { blob, filename: 'activitylogs.json' },
   });
 
   await expect(saveLogPromise).rejects.toThrowError('save-error');

--- a/tests/save-load.test.js
+++ b/tests/save-load.test.js
@@ -35,133 +35,23 @@ describe('load file functionalities', () => {
 });
 
 describe('save file functionalities', () => {
-  test('Save saveAsJSON should create a blob url and download it', async () => {
-    const downloadFileFn = jest.spyOn(save, 'downloadFile');
-
-    const createObjectURL = jest.fn();
-    const revokeObjectURL = jest.fn();
-    window.URL = { createObjectURL, revokeObjectURL };
-
-    const download = jest.fn();
-    const addListener = jest.fn();
-    const removeListener = jest.fn();
+  test('saveAsJSON function should create a blob url and send a message to background', async () => {
+    const sendMessage = jest.fn();
 
     window.browser = {
-      downloads: {
-        download,
-        onChanged: { addListener, removeListener },
-      },
+      runtime: { sendMessage },
     };
 
-    createObjectURL.mockReturnValue('fake-blob-url');
-
     let listener;
-    addListener.mockImplementation((callback) => {
+    sendMessage.mockImplementation((callback) => {
       listener = callback;
-    });
-
-    download.mockImplementation(() => {
-      const id = 123;
-      setTimeout(() => {
-        listener({
-          state: { current: 'in_progress' },
-          id,
-        });
-        listener({
-          state: { current: 'complete' },
-          id,
-        });
-      }, 0);
-      return Promise.resolve(id);
     });
 
     const log = [{ prop1: 'log1' }];
     await save.saveAsJSON(log);
 
-    const blob = downloadFileFn.mock.calls[0][0];
-    const blobContent = load.readFile(blob);
-
-    await expect(blobContent).resolves.toBe(JSON.stringify(log));
-
-    expect(downloadFileFn).toHaveBeenCalledTimes(1);
-    expect(download).toHaveBeenCalledTimes(1);
-    expect(download).toHaveBeenCalledWith({
-      url: 'fake-blob-url',
-      filename: 'activitylogs.json',
-    });
-
-    expect(addListener).toHaveBeenCalledTimes(1);
-    expect(addListener).toHaveBeenCalledWith(listener);
-
-    expect(removeListener).toHaveBeenCalledTimes(1);
-    expect(removeListener).toHaveBeenCalledWith(listener);
-
-    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
-    expect(revokeObjectURL).toHaveBeenCalledWith('fake-blob-url');
-
-    downloadFileFn.mockRestore();
-  });
-
-  test('Save saveAsJSON should return error message if error is encountered', async () => {
-    const downloadFileFn = jest.spyOn(save, 'downloadFile');
-
-    const createObjectURL = jest.fn();
-    const revokeObjectURL = jest.fn();
-    window.URL = { createObjectURL, revokeObjectURL };
-
-    const download = jest.fn();
-    const addListener = jest.fn();
-    const removeListener = jest.fn();
-    window.browser = {
-      downloads: {
-        download,
-        onChanged: { addListener, removeListener },
-      },
-    };
-
-    createObjectURL.mockReturnValue('fake-blob-url');
-
-    let listener;
-    addListener.mockImplementation((callback) => {
-      listener = callback;
-    });
-
-    download.mockImplementation(() => {
-      setTimeout(() => {
-        listener({
-          state: { current: 'interrupted' },
-          error: 'save-error',
-        });
-      }, 0);
-      return Promise.resolve(1);
-    });
-
-    const log = [{ prop1: 'log1' }];
-
-    const saveAsJson = save.saveAsJSON(log);
-    await expect(saveAsJson).rejects.toThrowError('save-error');
-
-    const blob = downloadFileFn.mock.calls[0][0];
-
-    const blobContent = load.readFile(blob);
-    await expect(blobContent).resolves.toBe(JSON.stringify(log));
-
-    expect(downloadFileFn).toHaveBeenCalledTimes(1);
-    expect(download).toHaveBeenCalledTimes(1);
-    expect(download).toHaveBeenCalledWith({
-      url: 'fake-blob-url',
-      filename: 'activitylogs.json',
-    });
-
-    expect(addListener).toHaveBeenCalledTimes(1);
-    expect(addListener).toHaveBeenCalledWith(listener);
-
-    expect(removeListener).toHaveBeenCalledTimes(1);
-    expect(removeListener).toHaveBeenCalledWith(listener);
-
-    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
-    expect(revokeObjectURL).toHaveBeenCalledWith('fake-blob-url');
-
-    downloadFileFn.mockRestore();
+    expect(sendMessage).toHaveBeenCalled();
+    expect(listener.requestType).toBe('saveLogs');
+    expect(listener.requestTo).toBe('ext-monitor');
   });
 });

--- a/tests/save-load.test.js
+++ b/tests/save-load.test.js
@@ -35,7 +35,7 @@ describe('load file functionalities', () => {
 });
 
 describe('save file functionalities', () => {
-  test('saveAsJSON function should create a blob url and send a message to background', async () => {
+  test('saveAsJSON function should send a message to background', async () => {
     const sendMessage = jest.fn();
 
     window.browser = {
@@ -47,8 +47,7 @@ describe('save file functionalities', () => {
       listener = callback;
     });
 
-    const log = [{ prop1: 'log1' }];
-    await save.saveAsJSON(log);
+    await save.saveAsJSON();
 
     expect(sendMessage).toHaveBeenCalled();
     expect(listener.requestType).toBe('saveLogs');


### PR DESCRIPTION
Fixes #22 

- It creates a new panel named "Extension Activity" in the developer toolbox. 
- tabId is retrieved when the developer toolbox has been opened and generated the activity log page url link `activitylog.html?filterTabId=tabId`
- the activitylog page is loaded lazily when the user selects the panel.