### PR TITLE
feat: start monitoring newly installed extensions automatically

### DIFF
--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -9,9 +9,10 @@ export default class ExtensionMonitor {
   extensionMapList = new Map([]);
 
   async getAllExtensions() {
+    const selfId = browser.runtime.id;
     const extensions = await browser.management.getAll();
     return extensions.filter((extension) => {
-      return extension.type === 'extension' && extension.id !== this.selfId;
+      return extension.type === 'extension' && extension.id !== selfId;
     });
   }
 
@@ -86,7 +87,8 @@ export default class ExtensionMonitor {
   }
 
   onInstalledExtension = ({ id, type }) => {
-    if (type !== 'extension' || id === this.selfId) {
+    const selfId = browser.runtime.id;
+    if (type !== 'extension' || id === selfId) {
       return;
     }
 
@@ -158,7 +160,6 @@ export default class ExtensionMonitor {
   };
 
   init() {
-    this.selfId = browser.runtime.id;
     browser.runtime.onMessage.addListener(this.messageListener);
     browser.tabs.onRemoved.addListener(this.onRemovedListener);
   }

--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -9,10 +9,11 @@ export default class ExtensionMonitor {
   extensionMapList = new Map([]);
 
   async getAllExtensions() {
-    const selfId = browser.runtime.id;
     const extensions = await browser.management.getAll();
     return extensions.filter((extension) => {
-      return extension.type === 'extension' && extension.id !== selfId;
+      return (
+        extension.type === 'extension' && extension.id !== browser.runtime.id
+      );
     });
   }
 
@@ -87,8 +88,7 @@ export default class ExtensionMonitor {
   }
 
   onInstalledExtension = ({ id, type }) => {
-    const selfId = browser.runtime.id;
-    if (type !== 'extension' || id === selfId) {
+    if (type !== 'extension' || id === browser.runtime.id) {
       return;
     }
 

--- a/src/lib/ext-monitor.js
+++ b/src/lib/ext-monitor.js
@@ -10,9 +10,8 @@ export default class ExtensionMonitor {
 
   async getAllExtensions() {
     const extensions = await browser.management.getAll();
-    const self = await browser.management.getSelf();
     return extensions.filter((extension) => {
-      return extension.type === 'extension' && extension.id !== self.id;
+      return extension.type === 'extension' && extension.id !== this.selfId;
     });
   }
 
@@ -43,35 +42,63 @@ export default class ExtensionMonitor {
     };
   }
 
+  async startMonitor() {
+    if (this.hasActivityListeners()) {
+      throw new Error('EAM is already running');
+    }
+
+    const extensions = await this.getAllExtensions();
+    extensions.forEach((extension) => {
+      this.addMonitorListener(extension.id);
+    });
+
+    browser.management.onInstalled.addListener(this.onInstalledExtension);
+    browser.management.onUninstalled.addListener(this.onUninstalledExtension);
+  }
+
   hasActivityListeners() {
     return this.extensionMapList.size > 0;
   }
 
-  async startMonitor() {
-    if (!this.hasActivityListeners()) {
-      const extensions = await this.getAllExtensions();
-      extensions.forEach((extension) => {
-        const listener = this.createLogListener();
-        this.extensionMapList.set(extension.id, listener);
-        browser.activityLog.onExtensionActivity.addListener(
-          listener,
-          extension.id
-        );
-      });
-    } else {
-      throw new Error('EAM is already running');
-    }
+  addMonitorListener(extensionId) {
+    const listener = this.createLogListener();
+    this.extensionMapList.set(extensionId, listener);
+    browser.activityLog.onExtensionActivity.addListener(listener, extensionId);
   }
 
   stopMonitor() {
     this.extensionMapList.forEach((listener, extensionId) => {
-      browser.activityLog.onExtensionActivity.removeListener(
-        listener,
-        extensionId
-      );
-      this.extensionMapList.delete(extensionId);
+      this.removeMonitorListener(extensionId, listener);
     });
+
+    browser.management.onInstalled.removeListener(this.onInstalledExtension);
+    browser.management.onUninstalled.removeListener(
+      this.onUninstalledExtension
+    );
   }
+
+  removeMonitorListener(extensionId, listener) {
+    browser.activityLog.onExtensionActivity.removeListener(
+      listener,
+      extensionId
+    );
+    this.extensionMapList.delete(extensionId);
+  }
+
+  onInstalledExtension = ({ id, type }) => {
+    if (type !== 'extension' || id === this.selfId) {
+      return;
+    }
+
+    this.addMonitorListener(id);
+  };
+
+  onUninstalledExtension = ({ id }) => {
+    if (this.extensionMapList.has(id)) {
+      const listener = this.extensionMapList.get(id);
+      this.removeMonitorListener(id, listener);
+    }
+  };
 
   messageHandlers = {
     clearLogs: () => (this.logs = []),
@@ -131,6 +158,7 @@ export default class ExtensionMonitor {
   };
 
   init() {
+    this.selfId = browser.runtime.id;
     browser.runtime.onMessage.addListener(this.messageListener);
     browser.tabs.onRemoved.addListener(this.onRemovedListener);
   }

--- a/tests/ext-monitor.test.js
+++ b/tests/ext-monitor.test.js
@@ -15,7 +15,8 @@ test('getAllExtensions should return all extensions but themes and self', async 
 
   window.browser = {
     management: { getAll },
-    runtime: { onMessage: { addListener: addListener }, id: selfExt.id },
+    runtime: { onMessage: { addListener }, id: selfExt.id },
+    tabs: { onRemoved: { addListener } },
   };
 
   const extMonitor = new ExtensionMonitor();
@@ -116,6 +117,7 @@ describe('start extension monitoring and register event listeners', () => {
         onInstalled: { addListener: onInstalledAddListener },
         onUninstalled: { addListener: onUninstalledAddListener },
       },
+      runtime: { id: selfExt.id },
     };
 
     const extMonitor = new ExtensionMonitor();
@@ -361,7 +363,7 @@ test('listeners are registered at initialization', () => {
   const tabsRemovedAddListener = jest.fn();
 
   window.browser = {
-    runtime: { onMessage: { addListener: runtimeMessageAddListener }, id: 'ext1' },
+    runtime: { onMessage: { addListener: runtimeMessageAddListener } },
     tabs: { onRemoved: { addListener: tabsRemovedAddListener } },
   };
 
@@ -371,7 +373,6 @@ test('listeners are registered at initialization', () => {
 
   extMonitor.init();
 
-  expect(extMonitor.selfId).toBe('ext1');
   expect(runtimeMessageAddListener).toHaveBeenCalledWith(messageListenerFn);
   expect(tabsRemovedAddListener).toHaveBeenCalledWith(onRemovedListenerFn);
 });

--- a/tests/ext-monitor.test.js
+++ b/tests/ext-monitor.test.js
@@ -123,8 +123,6 @@ describe('start extension monitoring and register event listeners', () => {
     const extMonitor = new ExtensionMonitor();
     const getAllExtensionsFn = jest.spyOn(extMonitor, 'getAllExtensions');
 
-    extMonitor.selfId = selfExt.id;
-
     getAllExtensionsFn.mockResolvedValue(initialMonitoringExts);
 
     expect(extMonitor.extensionMapList.size).toBe(0);
@@ -136,7 +134,7 @@ describe('start extension monitoring and register event listeners', () => {
     // being called with new extension's info.
     extMonitor.onInstalledExtension(newExtension);
 
-    // Since this is a theme, it will not be monitored.
+    // Since this is a theme, it should not be monitored.
     extMonitor.onInstalledExtension(newTheme);
 
     let monitoringExtIds = [];


### PR DESCRIPTION
Fixes #23 

This PR does -
- Start monitor newly installed extensions automatically.
- Stop monitoring (removing listener) for uninstalled extensions automatically.
