### PR TITLE
fix: space in JSON stringify, regression from PR #17

### DIFF
--- a/src/lib/web-component/log-view/log-view-element.js
+++ b/src/lib/web-component/log-view/log-view-element.js
@@ -81,7 +81,7 @@ export class LogView extends HTMLElement {
   }
 
   openDetailSidebar(logDetails) {
-    const logString = JSON.stringify(logDetails);
+    const logString = JSON.stringify(logDetails, null, 2);
     this.logDetails.textContent = logString;
     this.logTableWrapper.classList.add('width-60');
     this.logDetailWrapper.hidden = false;


### PR DESCRIPTION
This is a regression from PR #17. 

I had mistakenly removed the [`JSON stringify spacing` from detail sidebar](https://github.com/mozilla/extension-activity-monitor/pull/17/files#diff-f8ea6175e60fead7424fdb5348d747daL64).