### PR TITLE
fix: contextMenu listener returned when selected Element is null

### DIFF
--- a/src/lib/web-component/filter-timestamp/filter-timestamp-element.js
+++ b/src/lib/web-component/filter-timestamp/filter-timestamp-element.js
@@ -25,7 +25,7 @@ export class FilterTimestamp extends HTMLElement {
 
   setFilterRange = (info) => {
     const selectedEl = browser.menus.getTargetElement(info.targetElementId);
-    const selectedRow = selectedEl.closest('tr');
+    const selectedRow = selectedEl?.closest('tr');
 
     if (!selectedRow) {
       return;


### PR DESCRIPTION
## STR
1. Open Activity Log page from popup.
2. Open another Activity Log page from popup keeping the first one alive.
3. Collect some logs in the table view. 
4. Apply timestamp filtering.

You will find a console error saying: `can't access property "closest", selectedEl is null`

When we have multiple activity log page opened at a time, multiple context menu event listeners are being assigned but we get only one `selectedEl` from where the context event has been called.  
We should return when `selectedEl` is null.